### PR TITLE
Refine monitor summary date display

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -14,6 +14,7 @@ from store import (
 from bot.keyboards import kb_main, kb_date_picker, kb_theatre_picker, kb_interval_picker, kb_duration_picker, kb_heartbeat_picker
 from bot.telegram_api import send_text, send_alert, answer_cbq, get_updates
 from bot.commands import ensure_bot_commands
+from bot.utils import format_date_list, format_window
 from utils import titled, movie_title_from_url
 from config import TELEGRAM_ALLOWED_CHAT_IDS as _ALLOWED, BOT_OFFSET_FILE as _BOT_OFF
 def _health_summary() -> str:
@@ -99,11 +100,15 @@ def _eta(row) -> str:
 
 def _monitor_summary(r) -> str:
     th = len(json.loads(r["theatres"]) if r["theatres"] else [])
-    return (f"[{r['id']}] {r['state']} • every {r['interval_min']}m • next ~ {_eta(r)}\n"
-            f"Dates: {r['dates']}  |  Theatres: {th}  |  Window: {(r['time_start'] or '—')}–{(r['time_end'] or '—')}\n"
-            f"Mode: {r['mode'] or 'FIXED'} | Rolling: {r['rolling_days']} | Until: {r['end_date'] or '—'}\n"
-            f"Last run: {_fmt_ts(r['last_run_ts'])}  |  Last alert: {_fmt_ts(r['last_alert_ts'])}\n"
-            f"URL: {r['url']}")
+    dates = format_date_list(r["dates"])
+    window = format_window(r.get("time_start"), r.get("time_end"))
+    return (
+        f"[{r['id']}] {r['state']} • every {r['interval_min']}m • next ~ {_eta(r)}\n"
+        f"Dates: {dates}  |  Theatres: {th}  |  Window: {window}\n"
+        f"Mode: {r['mode'] or 'FIXED'} | Rolling: {r['rolling_days']} | Until: {r['end_date'] or '—'}\n"
+        f"Last run: {_fmt_ts(r['last_run_ts'])}  |  Last alert: {_fmt_ts(r['last_alert_ts'])}\n"
+        f"URL: {r['url']}"
+    )
 
 # --- helpers: theatre discovery for create flow ---
 def _discover_theatre_names(url: str, d8: str) -> list[str]:

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from datetime import datetime
+from typing import Optional
+
+
+def format_date(d: str) -> str:
+    """Return human friendly date like '12 Aug'."""
+    try:
+        return datetime.strptime(d, "%Y%m%d").strftime("%d %b")
+    except ValueError:
+        return d
+
+
+def format_date_list(date_str: Optional[str]) -> str:
+    """Format comma separated YYYYMMDD list."""
+    if not date_str:
+        return "—"
+    parts = [format_date(x) for x in date_str.split(",") if x]
+    return ", ".join(parts) if parts else "—"
+
+
+def format_time(t: Optional[str]) -> str:
+    """Format HH:MM into 'H:MM AM/PM'."""
+    if not t:
+        return "—"
+    try:
+        return datetime.strptime(t, "%H:%M").strftime("%I:%M %p").lstrip("0")
+    except ValueError:
+        return t
+
+
+def format_window(start: Optional[str], end: Optional[str]) -> str:
+    """Combine start and end time into a window string."""
+    return f"{format_time(start)}–{format_time(end)}"


### PR DESCRIPTION
## Summary
- Add bot/utils module for date and time formatting
- Use formatted dates and window in monitor summary for clearer alerts

## Testing
- `python -m py_compile bot/utils.py bot/bot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b12c640e4832fa0ae8b677673c655