### PR TITLE
Add centralized logging with env-controlled levels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-ENV TZ=Asia/Kolkata
+ENV TZ=Asia/Kolkata \
+    LOG_LEVEL=INFO \
+    PYTHONUNBUFFERED=1
 CMD ["python","bot/bot.py"]

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import os, time, re, json, secrets, sys
 from typing import List, Set
+import logging
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -16,6 +17,10 @@ from bot.telegram_api import send_text, send_alert, answer_cbq, get_updates
 from bot.commands import ensure_bot_commands
 from utils import titled, movie_title_from_url
 from config import TELEGRAM_ALLOWED_CHAT_IDS as _ALLOWED, BOT_OFFSET_FILE as _BOT_OFF
+from logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 def _health_summary() -> str:
     import shutil, os
     lines = []
@@ -872,9 +877,9 @@ def main():
     if os.environ.get("TELEGRAM_BOT_TOKEN"):
         ok=ensure_bot_commands()
         if not ok:
-            print("Failed to update commands.")
+            logger.error("Failed to update commands.")
     else:
-        print("TELEGRAM_BOT_TOKEN not set; skipping setMyCommands")
+        logger.warning("TELEGRAM_BOT_TOKEN not set; skipping setMyCommands")
     try:
         with open(UPD_OFF,"r") as f: offset = int((f.read() or "0").strip())
     except Exception:
@@ -898,7 +903,8 @@ def main():
                 with open(UPD_OFF,"w") as f: f.write(str(offset))
             except Exception: pass
         except Exception as e:
-            print("poll error:", e); time.sleep(2)
+            logger.exception("poll error")
+            time.sleep(2)
 
 if __name__ == "__main__":
     main()

--- a/docker.compose.yaml
+++ b/docker.compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       TZ: Asia/Kolkata
       BMS_FORCE_UC: "1"
+      LOG_LEVEL: "INFO"
     volumes:
       - /var/lib/bms/artifacts:/app/artifacts
     shm_size: "1g"
@@ -27,6 +28,7 @@ services:
     environment:
       TZ: Asia/Kolkata
       BMS_FORCE_UC: "1"
+      LOG_LEVEL: "INFO"
     volumes:
       - /var/lib/bms/artifacts:/app/artifacts
     shm_size: "1g"

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,36 @@
+import logging
+import logging.config
+import os
+
+_configured = False
+
+def setup_logging() -> None:
+    global _configured
+    if _configured:
+        return
+    level = os.getenv("LOG_LEVEL", "INFO").upper()
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "standard": {
+                "format": "%(asctime)s %(levelname)s [%(name)s] %(message)s",
+            }
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "standard",
+                "stream": "ext://sys.stdout",
+            }
+        },
+        "root": {
+            "level": level,
+            "handlers": ["console"],
+        },
+    }
+    logging.config.dictConfig(logging_config)
+    _configured = True
+
+# Configure logging when module is imported
+setup_logging()

--- a/run_local.sh
+++ b/run_local.sh
@@ -14,6 +14,9 @@ fi
 
 mkdir -p "$ROOT/artifacts"
 
+# default log level
+export LOG_LEVEL=${LOG_LEVEL:-INFO}
+
 cmd="${1:-bot}"
 shift || true
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import os, re, time, json, traceback
 from typing import List, Dict, Tuple
 from datetime import datetime, timedelta
+import logging
+
 from utils import titled
 from config import SCHEDULER_SLEEP_SEC as _SLEEP
+from logging_config import setup_logging
 
 from bot.telegram_api import send_text, send_alert
 from services.monitor_service import report_error, format_new_shows, build_new_shows_keyboard
@@ -16,6 +19,9 @@ from store import (
 from common import ensure_date_in_url, fuzzy, roll_dates, to_bms_date, within_time_window
 from scraper import get_driver, set_trace as set_scr_trace, parse_theatres
 from services.driver_manager import DriverManager
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN","")
 FALLBACK_CHAT = os.environ.get("TELEGRAM_CHAT_ID","")
@@ -240,10 +246,10 @@ def main_loop(debug=False, trace=False, artifacts_dir="./artifacts", sleep_sec=N
                         else:
                             _run_monitor(dm, r, heartbeat_book)
                 except Exception as e:
-                    print("monitor error:", e)
+                    logger.exception("monitor error")
                     report_error(r, e)
         except Exception as outer:
-            print("scheduler loop error:", outer)
+            logger.exception("scheduler loop error")
             time.sleep(3)
         time.sleep(int(sleep_sec or _SLEEP))
 

--- a/scraper.py
+++ b/scraper.py
@@ -2,11 +2,16 @@
 from __future__ import annotations
 import os, re, time, random, tempfile, subprocess, json
 from typing import List, Tuple, Optional
+import logging
 
 from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
+from logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 # ---------- trace / artifacts ----------
 _TRACE = False
@@ -22,7 +27,7 @@ def set_trace(enabled: bool, artifacts_dir: Optional[str] = None):
 
 def _dbg(msg: str):
     if _TRACE:
-        print(f"[trace] {msg}", flush=True)
+        logger.debug(msg)
 
 def _save_artifacts(driver, label: str):
     if not (_TRACE and _ARTIFACTS_DIR):
@@ -156,8 +161,8 @@ def get_driver(debug: bool = False):
             _inject_stealth(d); _ua_override(d)
             _dbg("selenium driver OK")
             return d
-        except Exception as e:
-            print(f"[driver] Selenium failed: {e}")
+        except Exception:
+            logger.exception("[driver] Selenium failed")
 
     try:
         import undetected_chromedriver as uc
@@ -172,8 +177,8 @@ def get_driver(debug: bool = False):
         d.set_page_load_timeout(60); _inject_stealth(d); _ua_override(d)
         _dbg("UC driver OK")
         return d
-    except Exception as e:
-        print(f"[driver] UC failed: {e}")
+    except Exception:
+        logger.exception("[driver] UC failed")
         return None
 
 # ---------- Navigation ----------

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -15,6 +15,9 @@ fi
 
 mkdir -p "$ROOT/artifacts"
 
+# default log level
+export LOG_LEVEL=${LOG_LEVEL:-INFO}
+
 cmd="${1:-bot}"
 shift || true
 
@@ -60,6 +63,9 @@ elif [ -f "$ROOT/scripts/env.sh" ]; then
 fi
 
 mkdir -p "$ROOT/artifacts"
+
+# default log level
+export LOG_LEVEL=${LOG_LEVEL:-INFO}
 
 cmd="${1:-bot}"
 shift || true

--- a/worker.py
+++ b/worker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os, re, time, json
 from typing import List, Set, Optional
 from datetime import datetime, timedelta
+import logging
 from config import DEFAULT_HEARTBEAT_MINUTES as _DEF_HB
 
 from bot.telegram_api import send_text, send_alert
@@ -14,6 +15,10 @@ from common import ensure_date_in_url, fuzzy, roll_dates, to_bms_date, within_ti
 from scraper import set_trace as set_scr_trace, parse_theatres
 from services.driver_manager import DriverManager
 from services.monitor_service import report_error
+from logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN","")
 FALLBACK_CHAT = os.environ.get("TELEGRAM_CHAT_ID","")


### PR DESCRIPTION
## Summary
- centralize logging setup in `logging_config.py` with env-driven log level
- replace `print` statements with module loggers across the codebase
- wire Docker and scripts to surface structured logs via `LOG_LEVEL`

## Testing
- `python -m py_compile logging_config.py scheduler.py worker.py scraper.py bot/telegram_api.py bot/bot.py`
- `bash -n run_local.sh scripts/run_local.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b4a3146a8832f8d1af86b1f065259