### PR TITLE
Add FastAPI web dashboard with Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Start monitoring your favorite movies now! 🎭🎪
 - **Import/Export** - Backup and restore your monitor configurations
 - **Multi-user support** - Each user sees only their own monitors
 
+### 🌐 **Web Dashboard**
+- **FastAPI service** for viewing monitor status and logs
+- **Telegram login** or token based access control
+- **Edit intervals** and other settings through simple forms
+
 ### 🚀 **Reliable Infrastructure**
 - **Docker deployment** - Easy setup and scaling
 - **Error handling** - Automatic recovery and user notifications

--- a/docker.compose.yaml
+++ b/docker.compose.yaml
@@ -1,4 +1,19 @@
 services:
+  webapp:
+    image: bms-webapp:latest
+    build:
+      context: .
+      dockerfile: webapp/Dockerfile
+    container_name: bms-webapp
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      TZ: Asia/Kolkata
+    volumes:
+      - /var/lib/bms/artifacts:/app/artifacts
+    ports:
+      - "8000:8000"
+
   bot:
     image: bms-rev1:latest
     build:

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,0 +1,7 @@
+FROM --platform=linux/amd64 python:3.11-slim
+WORKDIR /app
+COPY webapp/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV TZ=Asia/Kolkata
+CMD ["uvicorn", "webapp.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -1,0 +1,79 @@
+from fastapi import FastAPI, Request, Depends, Form, HTTPException
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from starlette.middleware.sessions import SessionMiddleware
+import os, hmac, hashlib
+import store
+
+app = FastAPI()
+templates = Jinja2Templates(directory="webapp/templates")
+app.add_middleware(SessionMiddleware, secret_key=os.getenv("WEBAPP_SECRET_KEY", "change-me"))
+
+BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
+BOT_NAME = os.getenv("TELEGRAM_BOT_USERNAME", "")
+WEBAPP_TOKEN = os.getenv("WEBAPP_TOKEN")
+
+
+def verify_telegram(data: dict) -> bool:
+    """Verify Telegram login data using HMAC as per docs."""
+    if not BOT_TOKEN:
+        return False
+    auth_data = {k: v for k, v in data.items() if k != "hash"}
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(auth_data.items()))
+    secret_key = hashlib.sha256(BOT_TOKEN.encode()).digest()
+    h = hmac.new(secret_key, data_check.encode(), hashlib.sha256).hexdigest()
+    return h == data.get("hash")
+
+
+def get_current_user(request: Request):
+    user = request.session.get("user")
+    if user:
+        return user
+    if WEBAPP_TOKEN:
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer ") and hmac.compare_digest(auth.split(" ", 1)[1], WEBAPP_TOKEN):
+            return {"id": "token"}
+    raise HTTPException(status_code=401)
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login(request: Request):
+    if "hash" in request.query_params:
+        data = dict(request.query_params)
+        if verify_telegram(data):
+            request.session["user"] = {"id": data.get("id"), "username": data.get("username")}
+            return RedirectResponse("/", status_code=303)
+        raise HTTPException(status_code=400, detail="Invalid login")
+    return templates.TemplateResponse("login.html", {"request": request, "bot_name": BOT_NAME})
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request, user=Depends(get_current_user)):
+    conn = store.connect()
+    monitors = store.list_monitors(conn)
+    return templates.TemplateResponse("index.html", {"request": request, "monitors": monitors, "user": user})
+
+
+@app.get("/monitor/{mid}", response_class=HTMLResponse)
+async def monitor_detail(mid: str, request: Request, user=Depends(get_current_user)):
+    conn = store.connect()
+    monitor = store.get_monitor(conn, mid)
+    if not monitor:
+        raise HTTPException(status_code=404)
+    log_path = os.path.join("artifacts", f"{mid}.log")
+    logs = ""
+    if os.path.exists(log_path):
+        with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
+            logs = f.read()[-4000:]
+    return templates.TemplateResponse(
+        "monitor_detail.html",
+        {"request": request, "monitor": monitor, "logs": logs, "user": user},
+    )
+
+
+@app.post("/monitor/{mid}/edit")
+async def monitor_edit(mid: str, interval_min: int = Form(...), user=Depends(get_current_user)):
+    conn = store.connect()
+    if not store.set_interval(conn, mid, interval_min):
+        raise HTTPException(status_code=400, detail="Update failed")
+    return RedirectResponse(f"/monitor/{mid}", status_code=303)

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+jinja2==3.1.4
+python-multipart==0.0.9

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>BMS Monitors</title>
+</head>
+<body>
+<nav>
+  <a href="/">Home</a>
+  {% if user %}<span>Logged in as {{ user.username or user.id }}</span>{% endif %}
+</nav>
+<hr/>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Monitors</h2>
+<ul>
+{% for m in monitors %}
+  <li><a href="/monitor/{{ m['id'] }}">{{ m['id'] }} - {{ m['state'] }}</a></li>
+{% else %}
+  <li>No monitors</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/webapp/templates/login.html
+++ b/webapp/templates/login.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Login</title></head>
+<body>
+<script async src="https://telegram.org/js/telegram-widget.js?19" data-telegram-login="{{ bot_name }}" data-size="large" data-userpic="false" data-auth-url="/login" data-request-access="write"></script>
+</body>
+</html>

--- a/webapp/templates/monitor_detail.html
+++ b/webapp/templates/monitor_detail.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Monitor {{ monitor['id'] }}</h2>
+<p>State: {{ monitor['state'] }}</p>
+<p>URL: {{ monitor['url'] }}</p>
+<p>Interval: {{ monitor['interval_min'] }} minutes</p>
+<h3>Update Interval</h3>
+<form method="post" action="/monitor/{{ monitor['id'] }}/edit">
+  <label>Interval minutes: <input type="number" name="interval_min" value="{{ monitor['interval_min'] }}" /></label>
+  <button type="submit">Update</button>
+</form>
+<h3>Logs</h3>
+<pre style="background:#eee; padding:1em;">{{ logs }}</pre>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement FastAPI webapp with Telegram login or token auth
- display monitor status, logs and allow editing via forms
- dockerize webapp and integrate into docker compose

## Testing
- `python -m compileall webapp`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4a38874c832f8f2b8b9bc22e0853