### PR TITLE
Add pre-commit config and CI workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy

--- a/README.md
+++ b/README.md
@@ -344,16 +344,14 @@ cd bms
 
 # Install dependencies
 pip install -r requirements.txt
+pip install pre-commit
+pre-commit install
 
 # Run tests
 python -m pytest tests/
 
-# Format code
-black .
-isort .
-
-# Type checking
-mypy .
+# Lint and type-check
+pre-commit run --all-files
 ```
 
 ### Code Structure


### PR DESCRIPTION
## Summary
- add pre-commit configuration with black, isort, flake8, and mypy
- document pre-commit installation in README
- run pre-commit in CI

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md .github/workflows/pre-commit.yml`


------
https://chatgpt.com/codex/tasks/task_e_689b4a350d30832f9d29518061266ff3