### PR TITLE
Add Docker build workflow and make targets

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          IMAGE_TAG: ${{ github.ref_name }}
+        run: |
+          make build
+          make push
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+COMPOSE_FILE = docker.compose.yaml
+IMAGE_NAME ?= bms-rev1
+IMAGE_TAG ?= latest
+
+.PHONY: build push deploy
+
+build:
+	IMAGE_NAME=$(IMAGE_NAME) IMAGE_TAG=$(IMAGE_TAG) docker compose -f $(COMPOSE_FILE) build
+
+push:
+	IMAGE_NAME=$(IMAGE_NAME) IMAGE_TAG=$(IMAGE_TAG) docker compose -f $(COMPOSE_FILE) push
+
+deploy:
+	IMAGE_NAME=$(IMAGE_NAME) IMAGE_TAG=$(IMAGE_TAG) docker compose -f $(COMPOSE_FILE) up -d
+

--- a/docker.compose.yaml
+++ b/docker.compose.yaml
@@ -1,6 +1,6 @@
 services:
   bot:
-    image: bms-rev1:latest
+    image: ${IMAGE_NAME:-bms-rev1}:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile
@@ -17,7 +17,7 @@ services:
 
   # duplicate this service per monitor (one worker == one monitor)
   worker-sample:
-    image: bms-rev1:latest
+    image: ${IMAGE_NAME:-bms-rev1}:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- parameterize compose image name and tag
- add Makefile targets to build, push and deploy via docker compose
- build and push images to GHCR on tagged releases with GitHub Actions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b4a3b4dc0832fadfddc228a4bd521